### PR TITLE
Adds  microphone permission to info.plist

### DIFF
--- a/cognitiveservicesPlugin/config.xml
+++ b/cognitiveservicesPlugin/config.xml
@@ -21,6 +21,9 @@
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
+        <edit-config target="NSMicrophoneUsageDescription" file="*-Info.plist" mode="merge">
+            <string>need microphone access to record sounds</string>
+        </edit-config>
     </platform>
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <engine name="browser" spec="^5.0.4" />

--- a/cognitiveservicesPlugin/plugin.xml
+++ b/cognitiveservicesPlugin/plugin.xml
@@ -46,6 +46,10 @@
      <header-file src="src/ios/CDVCognitiveServices.h" />
      <source-file src="src/ios/CDVCognitiveServices.m" />
 
+     <config-file target="*-Info.plist" parent="NSMicrophoneUsageDescription">
+            <string>need microphone access to record sounds</string>
+      </config-file>
+
     <podspec>
       <config>
        <source url="https://github.com/CocoaPods/Specs/Specs/a/4/c"/>


### PR DESCRIPTION
Adds  microphone permission to info.plist
According to [this](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-media-capture/) , if we do not add a message into the info.plist, application may crashes